### PR TITLE
cachePath without "/" in the file name

### DIFF
--- a/src/main.mjs
+++ b/src/main.mjs
@@ -30,7 +30,7 @@ export const run = async () => {
   const cacheRestoreKey = `google-indexing-action-${siteUrlWithoutProtocol}`
   const cacheKey = `${cacheRestoreKey}-${Date.now()}`
   const cacheFileName = `${convertToFilePath(siteUrl)}`+".json";
-  const cachePath = path.join(".cache/", cacheFileName.replace("/", ""));
+  //const cachePath = path.join(".cache/", cacheFileName.replace("/", ""));
 
   const [sitemaps, pages] = await getSitemapPages(accessToken, siteUrl)
 

--- a/src/main.mjs
+++ b/src/main.mjs
@@ -94,7 +94,7 @@ export const run = async () => {
   core.info(``)
   core.info(`👍 Done, here's the status of all ${pages.length} pages:`)
   mkdirSync('.cache', { recursive: true })
-  writeFileSync(cachePath, JSON.stringify(statusPerUrl, null, 2))
+  //writeFileSync(cachePath, JSON.stringify(statusPerUrl, null, 2))
 
   for (const [status, pages] of Object.entries(pagesPerStatus)) {
     core.info(`• ${getEmojiForStatus(status)} ${status}: ${pages.length} pages`)

--- a/src/main.mjs
+++ b/src/main.mjs
@@ -29,7 +29,7 @@ export const run = async () => {
     .replace('/', '_')
   const cacheRestoreKey = `google-indexing-action-${siteUrlWithoutProtocol}`
   const cacheKey = `${cacheRestoreKey}-${Date.now()}`
-  const cacheFileName = `${convertToFilePath(siteUrl)}.json`;
+  const cacheFileName = siteUrlWithoutProtocol+".json";
   cacheFileName = cacheFileName.replace("/", "");
   const cachePath = ".cache/"+cacheFileName;
   const [sitemaps, pages] = await getSitemapPages(accessToken, siteUrl)

--- a/src/main.mjs
+++ b/src/main.mjs
@@ -31,8 +31,7 @@ export const run = async () => {
   const cacheKey = `${cacheRestoreKey}-${Date.now()}`
   const cacheFileName = `${convertToFilePath(siteUrl)}.json`;
   cacheFileName = cacheFileName.replace("/", "");
-  const cachePath = path.join(".cache/", cacheFileName);
-
+  const cachePath = ".cache/"+cacheFileName;
   const [sitemaps, pages] = await getSitemapPages(accessToken, siteUrl)
 
   if (sitemaps.length === 0) {

--- a/src/main.mjs
+++ b/src/main.mjs
@@ -30,8 +30,7 @@ export const run = async () => {
   const cacheRestoreKey = `google-indexing-action-${siteUrlWithoutProtocol}`
   const cacheKey = `${cacheRestoreKey}-${Date.now()}`
   const cacheFileName = siteUrlWithoutProtocol+".json";
-  cacheFileName = cacheFileName.replace("/", "");
-  const cachePath = ".cache/"+cacheFileName;
+  const cachePath = ".cache/"+"log.json";
   const [sitemaps, pages] = await getSitemapPages(accessToken, siteUrl)
 
   if (sitemaps.length === 0) {

--- a/src/main.mjs
+++ b/src/main.mjs
@@ -30,7 +30,7 @@ export const run = async () => {
   const cacheRestoreKey = `google-indexing-action-${siteUrlWithoutProtocol}`
   const cacheKey = `${cacheRestoreKey}-${Date.now()}`
   const cacheFileName = `${convertToFilePath(siteUrl)}`+".json";
-  const cachePath = ".cache/" + cacheFileName.replace("/", "");
+  const cachePath = path.join(".cache/", cacheFileName.replace("/", ""));
 
   const [sitemaps, pages] = await getSitemapPages(accessToken, siteUrl)
 

--- a/src/main.mjs
+++ b/src/main.mjs
@@ -29,8 +29,9 @@ export const run = async () => {
     .replace('/', '_')
   const cacheRestoreKey = `google-indexing-action-${siteUrlWithoutProtocol}`
   const cacheKey = `${cacheRestoreKey}-${Date.now()}`
-  const cacheFileName = siteUrlWithoutProtocol+".json";
-  const cachePath = ".cache/"+"log.json";
+  const cacheFileName = `${convertToFilePath(siteUrl)}.json`;
+  cacheFileName = cacheFileName.replace("/", "");
+  const cachePath = ".cache/"+cacheFileName;
   const [sitemaps, pages] = await getSitemapPages(accessToken, siteUrl)
 
   if (sitemaps.length === 0) {

--- a/src/main.mjs
+++ b/src/main.mjs
@@ -29,8 +29,8 @@ export const run = async () => {
     .replace('/', '_')
   const cacheRestoreKey = `google-indexing-action-${siteUrlWithoutProtocol}`
   const cacheKey = `${cacheRestoreKey}-${Date.now()}`
-  const cacheFileName = `${convertToFilePath(siteUrl)}`+".json";
-  //const cachePath = path.join(".cache/", cacheFileName.replace("/", ""));
+  const cacheFileName = `${convertToFilePath(siteUrl)}.json`;
+  const cachePath = path.join(".cache/", cacheFileName.replace("/", ""));
 
   const [sitemaps, pages] = await getSitemapPages(accessToken, siteUrl)
 
@@ -94,7 +94,7 @@ export const run = async () => {
   core.info(``)
   core.info(`👍 Done, here's the status of all ${pages.length} pages:`)
   mkdirSync('.cache', { recursive: true })
-  //writeFileSync(cachePath, JSON.stringify(statusPerUrl, null, 2))
+  writeFileSync(cachePath, JSON.stringify(statusPerUrl, null, 2))
 
   for (const [status, pages] of Object.entries(pagesPerStatus)) {
     core.info(`• ${getEmojiForStatus(status)} ${status}: ${pages.length} pages`)

--- a/src/main.mjs
+++ b/src/main.mjs
@@ -29,7 +29,8 @@ export const run = async () => {
     .replace('/', '_')
   const cacheRestoreKey = `google-indexing-action-${siteUrlWithoutProtocol}`
   const cacheKey = `${cacheRestoreKey}-${Date.now()}`
-  const cachePath = `.cache/${siteUrlWithoutProtocol}.json`
+  const cacheFileName = `${convertToFilePath(siteUrl)}`+".json";
+  const cachePath = ".cache/" + cacheFileName.replace("/", "");
 
   const [sitemaps, pages] = await getSitemapPages(accessToken, siteUrl)
 

--- a/src/main.mjs
+++ b/src/main.mjs
@@ -30,7 +30,8 @@ export const run = async () => {
   const cacheRestoreKey = `google-indexing-action-${siteUrlWithoutProtocol}`
   const cacheKey = `${cacheRestoreKey}-${Date.now()}`
   const cacheFileName = `${convertToFilePath(siteUrl)}.json`;
-  const cachePath = path.join(".cache/", cacheFileName.replace("/", ""));
+  cacheFileName = cacheFileName.replace("/", "");
+  const cachePath = path.join(".cache/", cacheFileName);
 
   const [sitemaps, pages] = await getSitemapPages(accessToken, siteUrl)
 


### PR DESCRIPTION
There is a bug (in my case with my url)

`
Error: ENOENT: no such file or directory, open '.cache/https_teenbiscuits.github.io_Pro2324/.json'
`

There is a case where the cache file could not be written since there are two "/" in the name instead of one.

Now is fixed

`
.cache/https_teenbiscuits.github.io_Pro2324.json
`

I'm a bit new to js so this is an easy patch for my use case.
